### PR TITLE
Update outdated CSS selectors of daily recommendations page

### DIFF
--- a/python_chefkoch/chefkoch.py
+++ b/python_chefkoch/chefkoch.py
@@ -289,12 +289,12 @@ def get_daily_recommendations(frm: int = 0, to: int = 2, category: str = "koche"
     r = requests.get(base_url + f"/rezepte/was-{category}-ich-heute/")
     soup = bs4.BeautifulSoup(r.text, features='html.parser')
 
-    article_divs = soup.findAll("div", class_="inspiration__entry")[frm:to+1]
+    article_divs = soup.findAll("div", class_="ds-recipe-card")[frm:to+1]
 
     articles = list()
     for article_div in article_divs:
-        if article_div.find("a", class_="card__link"):
-            articles.append(article_div.find("a", class_="card__link")["href"])
+        if article_div.find("a", class_="ds-recipe-card__link"):
+            articles.append(article_div.find("a", class_="ds-recipe-card__link")["href"])
 
     recipes = list()
     Recipe.generate_multiple(articles, recipes)


### PR DESCRIPTION
Seems like chefkoch.de updated their daily recommendations page which broke the CSS selectors being used by this library. This lead to empty results when using the `chefkoch.get_daily_recommendations()`:
```
>>> chefkoch.get_daily_recommendations(category="backe")
[]
>>> chefkoch.get_daily_recommendations(category="koche")
[]
```

This PR updates the CSS selectors in order to restore the functionality of this function. With the updated selectors,  `chefkoch.get_daily_recommendations()` returns recipes once again:
```
>>> chefkoch.get_daily_recommendations(category='backe')
[Recipe object 'Bailey's Gugelhupf', Recipe object 'Pfefferminzschokolade - Muffins', Recipe object 'Fiese Finger']
>>> chefkoch.get_daily_recommendations(category='koche')
[Recipe object 'Ungarische Hackfleischsuppe', Recipe object 'Lammkoteletts griechische Art', Recipe object 'Ofenguck']
```